### PR TITLE
Return a random greeting

### DIFF
--- a/greetings/greetings.go
+++ b/greetings/greetings.go
@@ -3,6 +3,7 @@ package greetings
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 )
 
 //Hello returns a greeting for the named person.
@@ -12,8 +13,22 @@ func Hello(name string) (string, error) {
 		return "", errors.New("empty name")
 	}
 
-	//If a name was received, return a value that embeds the name
-	//in a greeting message.
-	message := fmt.Sprintf("Hi, %v. Welcome!", name)
+	//Create a message using a random format.
+	message := fmt.Sprintf(randomFormat(), name)
 	return message, nil
+}
+
+// randomFormat returns one of a set of greeting messages. The returned
+// message is selected at random.
+func randomFormat() string {
+	//A slice of message formats.
+	formats := []string{
+		"Hi, %v. Welcome!",
+		"Great to see you, %v!",
+		"Hail, %v! Well met!",
+	}
+
+	//Return a randomly selected message format by specifying
+	// a random index for the slice of formats.
+	return formats[rand.Intn(len(formats))]
 }

--- a/hello/hello.go
+++ b/hello/hello.go
@@ -15,7 +15,7 @@ func main() {
 	log.SetFlags(0)
 
 	//Request a greeting message.
-	message, err := greetings.Hello("")
+	message, err := greetings.Hello("Gladys")
 	//If an error was returned, printit to the console and
 	//exit the program.
 	if err != nil {


### PR DESCRIPTION
## Related link
- Reffered link: https://go.dev/doc/tutorial/random-greeting
## Thing want to do 
- instead of returning a single greeting every time, it returns one of several predefined greeting messages.
## Why
- Follow tutorial
## Done
- Add a randomFormat function that returns a randomly selected format for a greeting message. Note that randomFormat starts with a lowercase letter, making it accessible only to code in its own package (in other words, it's not exported).
- In randomFormat, declare a formats slice with three message formats. When declaring a slice, you omit its size in the brackets, like this: []string. This tells Go that the size of the array underlying the slice can be dynamically changed.
- Use the [math/rand package](https://pkg.go.dev/math/rand/) to generate a random number for selecting an item from the slice.
- In Hello, call the randomFormat function to get a format for the message you'll return, then use the format and name value together to create the message.
- Return the message (or an error) as you did before.
## Didn't do
- Nothing
## Confirmation method
- Run `go run .` command and return different greeting each time.