### PR TITLE
Return greetings for multiple people

### DIFF
--- a/greetings/greetings.go
+++ b/greetings/greetings.go
@@ -18,6 +18,24 @@ func Hello(name string) (string, error) {
 	return message, nil
 }
 
+//Hellos returns a map that associates each of the named people
+// with a greeting message.
+func Hellos(names []string) (map[string]string, error) {
+	//A map to associate names with messages.
+	messages := make(map[string]string)
+	//Loop through the received slice of names, calling
+	// the Hello function to get a message for each name.
+	for _, name := range names {
+		message, err := Hello(name)
+		if err != nil {
+			return nil, err
+		}
+		//In the map, associate the retrieved message with
+		// the name.
+		messages[name] = message
+	}
+	return messages, nil
+}
 // randomFormat returns one of a set of greeting messages. The returned
 // message is selected at random.
 func randomFormat() string {

--- a/hello/hello.go
+++ b/hello/hello.go
@@ -14,10 +14,11 @@ func main() {
 	log.SetPrefix("greetings: ")
 	log.SetFlags(0)
 
-	//Request a greeting message.
-	message, err := greetings.Hello("Gladys")
-	//If an error was returned, printit to the console and
-	//exit the program.
+	//A slice of names.
+	names := []string{"Gladys", "Samantha", "Darrin"}
+
+	//Request a greeting messages for the names.
+	message, err := greetings.Hellos(names)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Related link
- Reffered link: https://go.dev/doc/tutorial/greetings-multiple-people
## Thing want to do 
- Add support for getting greetings for multiple people in one request
## Why
- Follow tutorial
## Done
- Add a Hellos function whose parameter is a slice of names rather than a single name. Also, you change one of its return types from a string to a map so you can return names mapped to greeting messages.
- Have the new Hellos function call the existing Hello function. This helps reduce duplication while also leaving both functions in place.
- Create a messages map to associate each of the received names (as a key) with a generated message (as a value). In Go, you initialize a map with the following syntax: make(map[key-type]value-type). You have the Hellos function return this map to the caller. For more about maps, see [Go maps in action](https://blog.golang.org/maps) on the Go blog.
- Loop through the names your function received, checking that each has a non-empty value, then associate a message with each. In this for loop, range returns two values: the index of the current item in the loop and a copy of the item's value. You don't need the index, so you use the Go blank identifier (an underscore) to ignore it. For more, see [The blank identifier](https://go.dev/doc/effective_go.html#blank) in Effective Go.
- Create a names variable as a slice type holding three names.
- Pass the names variable as the argument to the Hellos function.
## Didn't do
- Nothing
## Confirmation method
- `go run .`